### PR TITLE
fix: API 전송 전 줄바꿈 정규화

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,8 @@ const obsidian = require('obsidian');
 
 async function checkSpelling(text) {
   // Old speller handles max ~300 tokens per page; chunk to be safe
+  // Normalize newlines to a single space so the API doesn't concatenate words across line breaks
+  text = text.replace(/(\r\n|\n)+/g, ' ');
   const maxWords = 300;
   const tokens = text.split(/(\s+)/);
   const chunks = [];


### PR DESCRIPTION
## 문제

선택한 텍스트에 줄바꿈이 포함된 경우, 줄바꿈 문자(`\n`)가 그대로 나라 맞춤법 검사기 API에 전달됩니다. API가 줄바꿈을 단어 구분자로 처리하지 않아 줄 경계에 걸친 앞뒤 단어가 붙여쓴 것으로 잘못 인식되는 문제가 발생합니다.

## 수정

`checkSpelling` 함수 진입 시 연속된 줄바꿈(`\r\n`, `\n`)을 공백 하나로 치환한 뒤 API에 전송합니다.

```js
text = text.replace(/(\r\n|\n)+/g, ' ');
```